### PR TITLE
INFENG-255: Add Linux and WSL support

### DIFF
--- a/pachctl.rb
+++ b/pachctl.rb
@@ -7,27 +7,35 @@ class Pachctl < Formula
   homepage "github.com/pachyderm/pachyderm"
   version "v2.9.3"
 
-  if Hardware::CPU.intel?
-    url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_darwin_amd64.zip"
-    sha256 "c50837e45228cff53a09e95d37ff607b0132efd5bc252bbe359aa949df771114"
-
-    def install
-      bin.install buildpath/"pachctl"
+  on_macos do
+    on_arm do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_darwin_arm64.zip"
+      sha256 "6d1834cc627d503c88532cabd9b05ca4b6a48065c83054ad4ad8d3c4289901f4"
     end
-  end
-  if Hardware::CPU.arm?
-    url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_darwin_arm64.zip"
-    sha256 "6d1834cc627d503c88532cabd9b05ca4b6a48065c83054ad4ad8d3c4289901f4"
 
-    def install
-      bin.install buildpath/"pachctl"
+    on_intel do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_darwin_amd64.zip"
+      sha256 "c50837e45228cff53a09e95d37ff607b0132efd5bc252bbe359aa949df771114"
     end
   end
 
+  on_linux do
+    on_arm do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_linux_arm64.tar.gz"
+      sha256 "0c3eaa94c7e95f8920c461ae75976e60d725d7fd9fb9d3b1a0a0f11912deb7d4"
+    end
 
+    on_intel do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_linux_amd64.tar.gz"
+      sha256 "b8321a27d03ad4813b731d9be045a79ab22ec3018037ecdb21a26de01139f5f8"
+    end
+  end
+
+  def install
+    bin.install buildpath/"pachctl"
+  end
 
   test do
     system "#{bin}/pachctl version"
   end
-
 end

--- a/pachctl.rb.sh
+++ b/pachctl.rb.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+cat <<EOF > ${FORMULA_FILENAME}
+require "formula"
+require "language/go"
+require 'erb'
+
+class ${PACHCTL_CLASSNAME} < Formula
+  homepage "github.com/pachyderm/pachyderm"
+  version "v${VERSION}"
+
+  on_macos do
+    on_arm do
+      url "${MACOS_ARM64_URL}"
+      sha256 "${MACOS_ARM64_SHA}"
+    end
+
+    on_intel do
+      url "${MACOS_AMD64_URL}"
+      sha256 "${MACOS_AMD64_SHA}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "${LINUX_ARM64_URL}"
+      sha256 "${LINUX_ARM64_SHA}"
+    end
+
+    on_intel do
+      url "${LINUX_AMD64_URL}"
+      sha256 "${LINUX_AMD64_SHA}"
+    end
+  end
+
+  def install
+    bin.install buildpath/"pachctl"
+  end
+
+  test do
+    system "#{bin}/pachctl version"
+  end
+end
+EOF

--- a/pachctl@2.10.rb
+++ b/pachctl@2.10.rb
@@ -2,32 +2,39 @@ require "formula"
 require "language/go"
 require 'erb'
 
-
 class PachctlAT210 < Formula
   homepage "github.com/pachyderm/pachyderm"
   version "v2.10.0-alpha.4"
 
-  if Hardware::CPU.intel?
-    url "https://github.com/pachyderm/pachyderm/releases/download/v2.10.0-alpha.4/pachctl_2.10.0-alpha.4_darwin_amd64.zip"
-    sha256 "fb48fb20a9784698d7fc64a8e699012628e6ef6c87c973d7bbb92e066d0552d0"
-
-    def install
-      bin.install buildpath/"pachctl"
+  on_macos do
+    on_arm do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.10.0-alpha.4/pachctl_2.10.0-alpha.4_darwin_arm64.zip"
+      sha256 "dfa7f95ffa681ace8d7fb5d3bb7785747cce402a27618280323af80326a946e7"
     end
-  end
-  if Hardware::CPU.arm?
-    url "https://github.com/pachyderm/pachyderm/releases/download/v2.10.0-alpha.4/pachctl_2.10.0-alpha.4_darwin_arm64.zip"
-    sha256 "dfa7f95ffa681ace8d7fb5d3bb7785747cce402a27618280323af80326a946e7"
 
-    def install
-      bin.install buildpath/"pachctl"
+    on_intel do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.10.0-alpha.4/pachctl_2.10.0-alpha.4_darwin_amd64.zip"
+      sha256 "fb48fb20a9784698d7fc64a8e699012628e6ef6c87c973d7bbb92e066d0552d0"
     end
   end
 
+  on_linux do
+    on_arm do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.10.0-alpha.4/pachctl_2.10.0-alpha.4_linux_arm64.tar.gz"
+      sha256 "56a25241374c52a55aa3d3fe350ac4554b014ee8810fec7d07447341f3b32960"
+    end
 
+    on_intel do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.10.0-alpha.4/pachctl_2.10.0-alpha.4_linux_amd64.tar.gz"
+      sha256 "9c83f9b10cd22c9f40a7aefe84da6f9319771a3f9b8c69b8465b904d63b1a0ac"
+    end
+  end
+
+  def install
+    bin.install buildpath/"pachctl"
+  end
 
   test do
     system "#{bin}/pachctl version"
   end
-
 end

--- a/pachctl@2.9.rb
+++ b/pachctl@2.9.rb
@@ -2,32 +2,39 @@ require "formula"
 require "language/go"
 require 'erb'
 
-
 class PachctlAT29 < Formula
   homepage "github.com/pachyderm/pachyderm"
   version "v2.9.3"
 
-  if Hardware::CPU.intel?
-    url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_darwin_amd64.zip"
-    sha256 "c50837e45228cff53a09e95d37ff607b0132efd5bc252bbe359aa949df771114"
-
-    def install
-      bin.install buildpath/"pachctl"
+  on_macos do
+    on_arm do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_darwin_arm64.zip"
+      sha256 "6d1834cc627d503c88532cabd9b05ca4b6a48065c83054ad4ad8d3c4289901f4"
     end
-  end
-  if Hardware::CPU.arm?
-    url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_darwin_arm64.zip"
-    sha256 "6d1834cc627d503c88532cabd9b05ca4b6a48065c83054ad4ad8d3c4289901f4"
 
-    def install
-      bin.install buildpath/"pachctl"
+    on_intel do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_darwin_amd64.zip"
+      sha256 "c50837e45228cff53a09e95d37ff607b0132efd5bc252bbe359aa949df771114"
     end
   end
 
+  on_linux do
+    on_arm do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_linux_arm64.tar.gz"
+      sha256 "0c3eaa94c7e95f8920c461ae75976e60d725d7fd9fb9d3b1a0a0f11912deb7d4"
+    end
 
+    on_intel do
+      url "https://github.com/pachyderm/pachyderm/releases/download/v2.9.3/pachctl_2.9.3_linux_amd64.tar.gz"
+      sha256 "b8321a27d03ad4813b731d9be045a79ab22ec3018037ecdb21a26de01139f5f8"
+    end
+  end
+
+  def install
+    bin.install buildpath/"pachctl"
+  end
 
   test do
     system "#{bin}/pachctl version"
   end
-
 end


### PR DESCRIPTION
Fixes #85.

* Modify update-formula.sh to support Linux binaries on both ARM64 and AMD64.

* Add pachctl.rb.sh as a template to generate updated pachctl@\*.rb files with new binaries. This file is basically just a shell script with a HEREDOC catted out to the new pachctl@\*.rb file, taking advantage of Bash's variable interpolation as a basic templating system.

* The formula file itself takes advantage of some Homebrew Ruby convenience blocks, like on_linux and on_arm to make decisions based on OS and architecture. I explored the bottle DSL syntax, but we don't use brew to bottle the binaries, so we can't use that at the moment.

* This changeset doesn't yet introduce backports for previous packages. That can be introduced as a separate change.

Note that the original `update-formula.sh` script clobbers any existing `pachctl@*.rb` file that might already exist with the same name, so I've retained that functionality.

The modified `update-formula.sh` script still depends on GNU coreutils for macOS users, because of `sha256sum`.

Testing this locally is a bit tricky because I believe Homebrew wants to use the `master` branch, and I'm not sure there's an easy way to override that ref. I have verified that it works on macOS and Linux, though. To test the `update-formula.sh` script itself, run/do the following:

1. `export VERSION=2.9.3`
2. `./update-formula.sh`
3. Open `pachctl@2.9.rb` in your second-favorite text editor and it should look a lot like the template in `pachctl.rb.sh`.